### PR TITLE
Enable WiFi, OTA and diagnostics

### DIFF
--- a/src/sensy_two.yaml
+++ b/src/sensy_two.yaml
@@ -3,6 +3,35 @@ esphome:
   includes:
     - components/sensy-two/sensy_two_component.h
 
+wifi:
+  ap:
+    ssid: "I am Sensy!"
+    ap_timeout: 1min
+
+captive_portal:
+
+esp32_improv:
+  authorizer: none
+  identify_duration: 10s
+  wifi_timeout: 1min
+  on_provisioned:
+    then:
+      - lambda: 'id(sensy_component)->read_firmware();'
+      - delay: 500ms
+      - lambda: 'id(sensy_component)->read_mac_address();'
+
+api:
+
+logger:
+  level: VERY_VERBOSE
+
+web_server:
+  port: 80
+  log: false
+
+ota:
+  platform: esphome
+
 uart:
   id: sensy_uart
   baud_rate: 115200
@@ -13,8 +42,44 @@ custom_component:
   - lambda: |-
       auto sensy = new esphome::sensytwo::SensyTwoComponent(&sensy_uart);
       id(sensy_component) = sensy;
-      return sensy->get_all_sensors();
+      return std::vector<esphome::Component*>{sensy};
     components: [sensy_component]
+
+text_sensor:
+  - platform: custom
+    lambda: |-
+      return id(sensy_component)->get_text_sensors();
+    text_sensors:
+      - id: radar_firmware
+        name: "RADAR | Firmware"
+        entity_category: diagnostic
+      - id: radar_mac
+        name: "RADAR | MAC"
+        entity_category: diagnostic
+
+sensor:
+  - platform: custom
+    lambda: |-
+      return id(sensy_component)->get_target_sensors();
+    sensors:
+      - id: t1_x
+      - id: t1_y
+      - id: t1_angle
+      - id: t1_speed
+      - id: t1_distance_resolution
+      - id: t1_distance
+      - id: t2_x
+      - id: t2_y
+      - id: t2_angle
+      - id: t2_speed
+      - id: t2_distance_resolution
+      - id: t2_distance
+      - id: t3_x
+      - id: t3_y
+      - id: t3_angle
+      - id: t3_speed
+      - id: t3_distance_resolution
+      - id: t3_distance
 
 number:
   - platform: template
@@ -143,6 +208,18 @@ number:
     on_value:
       then:
         - lambda: 'id(sensy_component)->set_detection_range_threshold(id(detection_threshold).state);'
+
+button:
+  - platform: template
+    name: "RADAR | Restart Module"
+    on_press:
+      - lambda: 'id(sensy_component)->restart_module();'
+    entity_category: config
+  - platform: template
+    name: "RADAR | Reset Points"
+    on_press:
+      - lambda: 'id(sensy_component)->reset_points();'
+    entity_category: config
 
 sensor:
   - platform: template


### PR DESCRIPTION
## Summary
- extend `SensyTwoComponent` with text sensors and AT command helpers
- add WiFi, captive portal and web server
- enable OTA and very verbose logging
- expose firmware and MAC address text sensors
- provide buttons for radar reset and point reset

## Testing
- `python3 - <<'PY'\nimport yaml, sys\nwith open('src/sensy_two.yaml') as f:\n    yaml.safe_load(f)\nprint('YAML OK')\nPY`

------
https://chatgpt.com/codex/tasks/task_e_687cf395ec68832aac69951b67b260e4