### PR TITLE
Switch to ESP-IDF to fit firmware in flash

### DIFF
--- a/src/sensy_two.yaml
+++ b/src/sensy_two.yaml
@@ -11,6 +11,8 @@ esphome:
 
 esp32:
   board: esp32dev
+  framework:
+    type: esp-idf
 
 external_components:
   - source:


### PR DESCRIPTION
## Summary
- use the ESP-IDF framework to reduce program size

## Testing
- `python3 -m py_compile src/components/sensy_two/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687d03503754832aa3da2e794d6967e7