### PR TITLE
Add configurable publish throttle

### DIFF
--- a/src/components/sensy_two/sensy_two_component.h
+++ b/src/components/sensy_two/sensy_two_component.h
@@ -27,6 +27,10 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
     detection_range_threshold_ = range_cm;
   }
 
+  void set_publish_interval_ms(uint32_t interval_ms) {
+    publish_interval_ms_ = interval_ms;
+  }
+
   void setup() override {
     this->radar_debug(3);
     this->radar_restart();
@@ -234,6 +238,15 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
   uint32_t item_index_ = 0;
 
   float detection_range_threshold_ = 600.0f;
+  uint32_t publish_interval_ms_ = 1000;
+
+  struct TargetState {
+    std::array<float, FIELDS> values{};
+  };
+
+  std::array<TargetState, MAX_TARGETS> current_state_{};
+  std::array<TargetState, MAX_TARGETS> last_published_{};
+  std::array<uint32_t, MAX_TARGETS> last_published_time_{};
 
   struct Person {
     uint32_t id;
@@ -335,6 +348,23 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
     return true;
   }
 
+  void maybe_publish(size_t index) {
+    uint32_t now = millis();
+    if (now - last_published_time_[index] < publish_interval_ms_) return;
+    if (current_state_[index].values != last_published_[index].values) {
+      last_published_time_[index] = now;
+      last_published_[index] = current_state_[index];
+      auto &vals = current_state_[index].values;
+      x_sensors_[index]->publish_state(vals[0]);
+      y_sensors_[index]->publish_state(vals[1]);
+      z_sensors_[index]->publish_state(vals[2]);
+      angle_sensors_[index]->publish_state(vals[3]);
+      speed_sensors_[index]->publish_state(vals[4]);
+      distance_resolution_sensors_[index]->publish_state(vals[5]);
+      distance_sensors_[index]->publish_state(vals[6]);
+    }
+  }
+
   void parse_ring() {
     switch (state_) {
       case SEARCHING_HEADER: {
@@ -416,32 +446,21 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
     float angle = (distance > 0.0f) ? atan2f(p.x, p.y) * 180.0f / M_PI : 0.0f;
     float speed = sqrtf(p.vx * p.vx + p.vy * p.vy + p.vz * p.vz);
 
-    auto publish = [&](float x, float y, float z, float ang, float spd, float dist) {
-      x_sensors_[index]->publish_state(x);
-      y_sensors_[index]->publish_state(y);
-      z_sensors_[index]->publish_state(z);
-      angle_sensors_[index]->publish_state(ang);
-      speed_sensors_[index]->publish_state(spd);
-      distance_resolution_sensors_[index]->publish_state(0);
-      distance_sensors_[index]->publish_state(dist);
-    };
-
+    TargetState state;
     if (distance > detection_range_threshold_) {
-      publish(0, 0, 0, 0, 0, 0);
+      state.values = {0, 0, 0, 0, 0, 0, 0};
     } else {
-      publish(p.x, p.y, p.z, angle, speed, distance);
+      state.values = {p.x, p.y, p.z, angle, speed, 0, distance};
     }
+    current_state_[index] = state;
+
+    maybe_publish(index);
   }
 
   void clear_targets() {
     for (size_t i = 0; i < MAX_TARGETS; ++i) {
-      x_sensors_[i]->publish_state(0);
-      y_sensors_[i]->publish_state(0);
-      z_sensors_[i]->publish_state(0);
-      angle_sensors_[i]->publish_state(0);
-      speed_sensors_[i]->publish_state(0);
-      distance_resolution_sensors_[i]->publish_state(0);
-      distance_sensors_[i]->publish_state(0);
+      current_state_[i].values = {0, 0, 0, 0, 0, 0, 0};
+      maybe_publish(i);
     }
   }
 
@@ -470,13 +489,9 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
   }
 
   void publish_empty(size_t index) {
-    x_sensors_[index]->publish_state(0);
-    y_sensors_[index]->publish_state(0);
-    z_sensors_[index]->publish_state(0);
-    angle_sensors_[index]->publish_state(0);
-    speed_sensors_[index]->publish_state(0);
-    distance_resolution_sensors_[index]->publish_state(0);
-    distance_sensors_[index]->publish_state(0);
+    if (index >= MAX_TARGETS) return;
+    current_state_[index].values = {0, 0, 0, 0, 0, 0, 0};
+    maybe_publish(index);
   }
 
   void assign_persons(const std::vector<Person> &persons) {

--- a/src/sensy_two.yaml
+++ b/src/sensy_two.yaml
@@ -643,6 +643,19 @@ number:
       then:
         - lambda: 'id(sensy_component)->set_detection_range_threshold(id(detection_threshold).state);'
 
+  - platform: template
+    id: publish_interval
+    name: "Publish Interval"
+    min_value: 100
+    max_value: 1000
+    step: 100
+    unit_of_measurement: "ms"
+    optimistic: true
+    restore_value: true
+    on_value:
+      then:
+        - lambda: 'id(sensy_component)->set_publish_interval_ms(id(publish_interval).state);'
+
 button:
   - platform: template
     name: "RADAR | Restart Module"


### PR DESCRIPTION
## Summary
- throttle target publishing to HA via new internal state mechanism
- add method to change update interval
- expose a publish interval slider in YAML

## Testing
- `g++ -std=c++17 -I. -c /tmp/test.cpp` *(fails: `esphome.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687def4fadec832abc2e0c61e6ce4621