### PR TITLE
Expose zone count

### DIFF
--- a/src/components/sensy_two/sensy_two_component.h
+++ b/src/components/sensy_two/sensy_two_component.h
@@ -545,6 +545,7 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
     raw_targets_[index] = {};
   }
 
+ public:
   int count_targets_in_zone(float x0, float x1, float y0, float y1,
                             float ex_x0, float ex_x1, float ex_y0,
                             float ex_y1) const {
@@ -575,6 +576,7 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
     return count;
   }
 
+ protected:
   void assign_persons(const std::vector<Person> &persons) {
     ESP_LOGI("SensyTwo", "Assigning %zu persons", persons.size());
     std::array<bool, MAX_TARGETS> seen{};


### PR DESCRIPTION
## Summary
- make `count_targets_in_zone` accessible to YAML templates

## Testing
- `python -m py_compile src/components/sensy_two/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687e41b89d9c832ab0e4366c35e77569