### PR TITLE
Add sensitivity slider

### DIFF
--- a/src/components/sensy_two/sensy_two_component.h
+++ b/src/components/sensy_two/sensy_two_component.h
@@ -35,6 +35,11 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
   void set_rotation_y_deg(float deg) { rotation_y_ = deg * M_PI / 180.0f; }
   void set_rotation_z_deg(float deg) { rotation_z_ = deg * M_PI / 180.0f; }
 
+  void set_sensitivity(int value) {
+    sensitivity_ = value;
+    this->radar_sensitivity(value);
+  }
+
   void setup() override {
     // this->radar_debug(3);
     this->radar_restart();
@@ -42,7 +47,7 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
     this->radar_report_interval(200);
     this->radar_monitor_interval(1);
     this->radar_heartbeat_timeout(10);
-    this->radar_sensitivity(2);
+    this->radar_sensitivity(sensitivity_);
     this->radar_seeking();
     this->radar_capture();
     if (auto *idf = static_cast<uart::IDFUARTComponent *>(this->parent_)) {
@@ -252,6 +257,7 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
   float rotation_x_ = 0.0f;
   float rotation_y_ = 0.0f;
   float rotation_z_ = 0.0f;
+  int sensitivity_ = 2;
 
   struct Person {
     uint32_t id;

--- a/src/sensy_two.yaml
+++ b/src/sensy_two.yaml
@@ -642,6 +642,20 @@ number:
               id(detection_threshold).state);
 
   - platform: template
+    id: radar_sensitivity
+    name: "Sensitivity"
+    min_value: 1
+    max_value: 19
+    step: 1
+    optimistic: true
+    restore_value: true
+    on_value:
+      then:
+        - lambda: |-
+            id(sensy_component)->set_sensitivity(
+              (int)id(radar_sensitivity).state);
+
+  - platform: template
     id: publish_interval
     name: "Publish Interval"
     min_value: 100


### PR DESCRIPTION
## Summary
- add a setter for radar sensitivity and call it from setup
- store the current sensitivity in the component
- expose a new number entity in the YAML example to set sensitivity

## Testing
- `git diff --color --compact-summary`

------
https://chatgpt.com/codex/tasks/task_e_687e69cdccbc832aae5e7825704e7ee1