### PR TITLE
Add radar timing controls

### DIFF
--- a/src/components/sensy_two/sensy_two_component.h
+++ b/src/components/sensy_two/sensy_two_component.h
@@ -40,13 +40,34 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
     this->radar_sensitivity(value);
   }
 
+  void set_report_interval_ms(int value) {
+    report_interval_ms_ = value;
+    this->radar_report_interval(value);
+  }
+
+  void set_monitor_interval_s(int value) {
+    monitor_interval_s_ = value;
+    this->radar_monitor_interval(value);
+  }
+
+  void set_heartbeat_interval_s(int value) {
+    heartbeat_interval_s_ = value;
+    this->radar_heartbeat_timeout(value);
+  }
+
+  void set_range_cm(int value) {
+    range_cm_ = value;
+    this->radar_range(value);
+  }
+
   void setup() override {
     // this->radar_debug(3);
     this->radar_restart();
     this->radar_start();
-    this->radar_report_interval(200);
-    this->radar_monitor_interval(1);
-    this->radar_heartbeat_timeout(10);
+    this->radar_report_interval(report_interval_ms_);
+    this->radar_monitor_interval(monitor_interval_s_);
+    this->radar_heartbeat_timeout(heartbeat_interval_s_);
+    this->radar_range(range_cm_);
     this->radar_sensitivity(sensitivity_);
     this->radar_seeking();
     this->radar_capture();
@@ -82,6 +103,12 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
   void radar_heartbeat_timeout(int value) {
     char cmd[32];
     snprintf(cmd, sizeof(cmd), "AT+HEATIME=%d\n", value);
+    this->write_str(cmd);
+    delay(100);
+  }
+  void radar_range(int value) {
+    char cmd[32];
+    snprintf(cmd, sizeof(cmd), "AT+RANGE=%d\n", value);
     this->write_str(cmd);
     delay(100);
   }
@@ -258,6 +285,10 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
   float rotation_y_ = 0.0f;
   float rotation_z_ = 0.0f;
   int sensitivity_ = 2;
+  int report_interval_ms_ = 200;
+  int monitor_interval_s_ = 1;
+  int heartbeat_interval_s_ = 10;
+  int range_cm_ = 600;
 
   struct Person {
     uint32_t id;

--- a/src/sensy_two.yaml
+++ b/src/sensy_two.yaml
@@ -645,6 +645,7 @@ number:
     step: 1
     optimistic: true
     restore_value: true
+    entity_category: diagnostic
     on_value:
       then:
         - lambda: |-
@@ -659,11 +660,80 @@ number:
     step: 1
     optimistic: true
     restore_value: true
+    entity_category: diagnostic
     on_value:
       then:
         - lambda: |-
             id(sensy_component)->set_sensitivity(
               (int)id(radar_sensitivity).state);
+
+  - platform: template
+    id: radar_report_interval
+    name: "RADAR | Report Interval"
+    min_value: 100
+    max_value: 10000
+    step: 100
+    unit_of_measurement: "ms"
+    optimistic: true
+    restore_value: true
+    initial_value: 200
+    entity_category: diagnostic
+    on_value:
+      then:
+        - lambda: |-
+            id(sensy_component)->set_report_interval_ms(
+              (int)id(radar_report_interval).state);
+
+  - platform: template
+    id: radar_monitor_interval
+    name: "RADAR | Monitor Interval"
+    min_value: 1
+    max_value: 99
+    step: 1
+    unit_of_measurement: "s"
+    optimistic: true
+    restore_value: true
+    initial_value: 1
+    entity_category: diagnostic
+    on_value:
+      then:
+        - lambda: |-
+            id(sensy_component)->set_monitor_interval_s(
+              (int)id(radar_monitor_interval).state);
+
+  - platform: template
+    id: radar_heartbeat_interval
+    name: "RADAR | Heartbeat Interval"
+    min_value: 10
+    max_value: 99
+    step: 1
+    unit_of_measurement: "s"
+    optimistic: true
+    restore_value: true
+    initial_value: 10
+    entity_category: diagnostic
+    on_value:
+      then:
+        - lambda: |-
+            id(sensy_component)->set_heartbeat_interval_s(
+              (int)id(radar_heartbeat_interval).state);
+
+  - platform: template
+    id: radar_range
+    name: "RADAR | Range"
+    min_value: 10
+    max_value: 1000
+    step: 10
+    unit_of_measurement: "cm"
+    optimistic: true
+    restore_value: true
+    initial_value: 600
+    entity_category: diagnostic
+    on_value:
+      then:
+        - lambda: |-
+            id(sensy_component)->set_range_cm(
+              (int)id(radar_range).state);
 
   - platform: template
     id: publish_interval


### PR DESCRIPTION
## Summary
- allow adjusting report, monitor, heartbeat intervals via template numbers
- allow adjusting radar range with AT+RANGE command
- mark radar settings as diagnostic and store their values
- restore timing and range settings during component setup

## Testing
- `python -m py_compile src/components/sensy_two/__init__.py`
- `yamllint -d '{extends: default, rules: {line-length: disable}}' src/sensy_two.yaml`


------
https://chatgpt.com/codex/tasks/task_e_687e6e97108c832ab507d6ec09e8f26e