### PR TITLE
Report speed as integer

### DIFF
--- a/src/components/sensy_two/sensy_two_component.h
+++ b/src/components/sensy_two/sensy_two_component.h
@@ -409,9 +409,10 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
       float angle = (distance > 0.0f) ? atan2f(x, y) * 180.0f / M_PI : 0.0f;
       float speed = sqrtf(vx * vx + vy * vy + vz * vz);
       auto r2 = [](float v) { return roundf(v * 100.0f) / 100.0f; };
+      auto r0 = [](float v) { return roundf(v); };
       state.values = {r2(x * 100), r2(y * 100), r2(z * 100), r2(angle),
-                      r2(speed * 100), 0, r2(distance * 100),
-                      raw_targets_[index].q * 1.0f};
+                      r0(speed * 100), raw_targets_[index].q * 1.0f,
+                      r2(distance * 100), raw_targets_[index].q * 1.0f};
     } else {
       state.values = {0, 0, 0, 0, 0, 0, 0, 0};
     }

--- a/src/sensy_two.yaml
+++ b/src/sensy_two.yaml
@@ -113,7 +113,7 @@ sensy_two:
     id: t1_speed
     name: "Target 01 Speed"
     unit_of_measurement: "cm/s"
-    accuracy_decimals: 2
+    accuracy_decimals: 0
     icon: mdi:speedometer
   t1_distance_resolution:
     id: t1_distance_resolution
@@ -154,7 +154,7 @@ sensy_two:
     id: t2_speed
     name: "Target 02 Speed"
     unit_of_measurement: "cm/s"
-    accuracy_decimals: 2
+    accuracy_decimals: 0
     icon: mdi:speedometer
   t2_distance_resolution:
     id: t2_distance_resolution
@@ -195,7 +195,7 @@ sensy_two:
     id: t3_speed
     name: "Target 03 Speed"
     unit_of_measurement: "cm/s"
-    accuracy_decimals: 2
+    accuracy_decimals: 0
     icon: mdi:speedometer
   t3_distance_resolution:
     id: t3_distance_resolution
@@ -236,7 +236,7 @@ sensy_two:
     id: t4_speed
     name: "Target 04 Speed"
     unit_of_measurement: "cm/s"
-    accuracy_decimals: 2
+    accuracy_decimals: 0
     icon: mdi:speedometer
   t4_distance_resolution:
     id: t4_distance_resolution
@@ -277,7 +277,7 @@ sensy_two:
     id: t5_speed
     name: "Target 05 Speed"
     unit_of_measurement: "cm/s"
-    accuracy_decimals: 2
+    accuracy_decimals: 0
     icon: mdi:speedometer
   t5_distance_resolution:
     id: t5_distance_resolution
@@ -318,7 +318,7 @@ sensy_two:
     id: t6_speed
     name: "Target 06 Speed"
     unit_of_measurement: "cm/s"
-    accuracy_decimals: 2
+    accuracy_decimals: 0
     icon: mdi:speedometer
   t6_distance_resolution:
     id: t6_distance_resolution
@@ -359,7 +359,7 @@ sensy_two:
     id: t7_speed
     name: "Target 07 Speed"
     unit_of_measurement: "cm/s"
-    accuracy_decimals: 2
+    accuracy_decimals: 0
     icon: mdi:speedometer
   t7_distance_resolution:
     id: t7_distance_resolution
@@ -400,7 +400,7 @@ sensy_two:
     id: t8_speed
     name: "Target 08 Speed"
     unit_of_measurement: "cm/s"
-    accuracy_decimals: 2
+    accuracy_decimals: 0
     icon: mdi:speedometer
   t8_distance_resolution:
     id: t8_distance_resolution
@@ -441,7 +441,7 @@ sensy_two:
     id: t9_speed
     name: "Target 09 Speed"
     unit_of_measurement: "cm/s"
-    accuracy_decimals: 2
+    accuracy_decimals: 0
     icon: mdi:speedometer
   t9_distance_resolution:
     id: t9_distance_resolution
@@ -482,7 +482,7 @@ sensy_two:
     id: t10_speed
     name: "Target 10 Speed"
     unit_of_measurement: "cm/s"
-    accuracy_decimals: 2
+    accuracy_decimals: 0
     icon: mdi:speedometer
   t10_distance_resolution:
     id: t10_distance_resolution


### PR DESCRIPTION
## Summary
- round speed values to integers when publishing target data
- adjust speed sensor accuracy in example firmware
- also publish target Q as the distance resolution

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687f41da4294832aa3f2598aa87abe8e