### PR TITLE
Add diagnostic sensors

### DIFF
--- a/src/components/sensy_two/__init__.py
+++ b/src/components/sensy_two/__init__.py
@@ -29,6 +29,7 @@ SENSOR_KEYS = [
 TEXT_SENSOR_KEYS = [
     "radar_firmware",
     "radar_mac",
+    "sensy_firmware",
 ]
 
 CONFIG_SCHEMA = (

--- a/src/components/sensy_two/sensy_two_component.h
+++ b/src/components/sensy_two/sensy_two_component.h
@@ -20,6 +20,7 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
  public:
   static const size_t MAX_TARGETS = 10;
   static const size_t FIELDS = 8;
+  static constexpr const char *FIRMWARE_VERSION = "v0.0.1";
   explicit SensyTwoComponent(uart::UARTComponent *parent)
       : uart::UARTDevice(parent) {}
 
@@ -41,6 +42,13 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
     this->radar_sensitivity(sensitivity_);
     this->radar_seeking();
     this->radar_capture();
+
+    if (this->radar_firmware)
+      this->radar_firmware->publish_state("unknown");
+    if (this->radar_mac)
+      this->radar_mac->publish_state("unknown");
+    if (this->sensy_firmware)
+      this->sensy_firmware->publish_state(FIRMWARE_VERSION);
 
     if (auto *idf = static_cast<uart::IDFUARTComponent *>(this->parent_)) {
       uart_num_ = static_cast<uart_port_t>(idf->get_hw_serial_number());
@@ -196,6 +204,7 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
 
   text_sensor::TextSensor *radar_firmware = new text_sensor::TextSensor();
   text_sensor::TextSensor *radar_mac = new text_sensor::TextSensor();
+  text_sensor::TextSensor *sensy_firmware = new text_sensor::TextSensor();
 
   std::array<sensor::Sensor *, MAX_TARGETS> x_sensors_{t1_x, t2_x, t3_x, t4_x, t5_x, t6_x, t7_x, t8_x, t9_x, t10_x};
   std::array<sensor::Sensor *, MAX_TARGETS> y_sensors_{t1_y, t2_y, t3_y, t4_y, t5_y, t6_y, t7_y, t8_y, t9_y, t10_y};

--- a/src/sensy_two.yaml
+++ b/src/sensy_two.yaml
@@ -495,6 +495,18 @@ sensy_two:
     unit_of_measurement: "cm"
     accuracy_decimals: 2
     icon: mdi:map-marker-distance
+  radar_firmware:
+    name: "RADAR | Firmware"
+    entity_category: diagnostic
+    icon: mdi:git
+  radar_mac:
+    name: "RADAR | MAC"
+    entity_category: diagnostic
+    icon: mdi:card-bulleted-settings
+  sensy_firmware:
+    name: "SENSY | Firmware"
+    entity_category: diagnostic
+    icon: mdi:git
 
 number:
   - platform: template
@@ -846,6 +858,34 @@ sensor:
         id(exclusion_x_begin).state, id(exclusion_x_end).state,
         id(exclusion_y_begin).state, id(exclusion_y_end).state);
 
+  - platform: internal_temperature
+    name: "ESP32 | Temperature"
+    entity_category: diagnostic
+    icon: mdi:thermometer
+    update_interval: 15s
+
+  - platform: uptime
+    name: "ESP32 | Uptime (Seconds)"
+    id: esp32_uptime_seconds
+    entity_category: diagnostic
+    icon: mdi:sort-clock-descending
+    update_interval: 15s
+    internal: true
+
+  - platform: template
+    name: "ESP32 | Uptime"
+    lambda: |-
+      int uptime = id(esp32_uptime_seconds).state;
+      int hours = uptime / 3600;
+      int minutes = (uptime % 3600) / 60;
+      int seconds = uptime % 60;
+      char buffer[10];
+      snprintf(buffer, sizeof(buffer), "%02d:%02d:%02d", hours, minutes, seconds);
+      return std::string(buffer);
+    icon: mdi:sort-clock-descending
+    entity_category: diagnostic
+    update_interval: 15s
+
 binary_sensor:
   - platform: template
     name: "Zone 1 Presence"
@@ -876,3 +916,52 @@ binary_sensor:
         id(zone3_y_begin).state, id(zone3_y_end).state,
         id(exclusion_x_begin).state, id(exclusion_x_end).state,
         id(exclusion_y_begin).state, id(exclusion_y_end).state) > 0;
+
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: "ESP32 | IP"
+      entity_category: diagnostic
+      icon: mdi:ip-network
+      update_interval: 15s
+    ssid:
+      name: "ESP32 | SSID"
+      entity_category: diagnostic
+      icon: mdi:wifi-settings
+      update_interval: 15s
+
+  - platform: template
+    name: "ESP32 | MAC"
+    entity_category: diagnostic
+    icon: mdi:card-bulleted-settings
+    lambda: |-
+      uint64_t mac = ESP.getEfuseMac();
+      char mac_str[18];
+      snprintf(mac_str, sizeof(mac_str), "%02X:%02X:%02X:%02X:%02X:%02X",
+        (uint8_t)(mac >> 40),
+        (uint8_t)(mac >> 32),
+        (uint8_t)(mac >> 24),
+        (uint8_t)(mac >> 16),
+        (uint8_t)(mac >> 8),
+        (uint8_t)(mac));
+      return std::string(mac_str);
+
+  - platform: template
+    name: "ESP32 | WiFi Strength"
+    entity_category: diagnostic
+    icon: mdi:signal-cellular-3
+    update_interval: 15s
+    lambda: |-
+      int rssi = WiFi.RSSI();
+      if (rssi < -90) {
+        return std::string("Very Weak");
+      } else if (rssi < -80) {
+        return std::string("Weak");
+      } else if (rssi < -70) {
+        return std::string("Moderate");
+      } else if (rssi < -60) {
+        return std::string("Strong");
+      } else {
+        return std::string("Very Strong");
+      }
+


### PR DESCRIPTION
## Summary
- extend component with new firmware text sensor
- publish diag text sensor states during setup
- expose radar and firmware sensors in YAML
- show ESP32 diagnostics like WiFi info, MAC, temperature and uptime

## Testing
- `esphome compile src/sensy_two.yaml` *(fails: feature only available with frameworks)*

------
https://chatgpt.com/codex/tasks/task_e_687f480729d8832a8a280ca38b1b1290