### PR TITLE
Fix build issues for esp-idf

### DIFF
--- a/src/sensy_two.yaml
+++ b/src/sensy_two.yaml
@@ -926,19 +926,11 @@ sensor:
     update_interval: 15s
     internal: true
 
-  - platform: template
-    name: "ESP32 | Uptime"
-    lambda: |-
-      int uptime = id(esp32_uptime_seconds).state;
-      int hours = uptime / 3600;
-      int minutes = (uptime % 3600) / 60;
-      int seconds = uptime % 60;
-      char buffer[10];
-      snprintf(buffer, sizeof(buffer), "%02d:%02d:%02d", hours, minutes, seconds);
-      return std::string(buffer);
-    icon: mdi:sort-clock-descending
+  - platform: wifi_signal
+    name: "ESP32 | WiFi RSSI"
     entity_category: diagnostic
     update_interval: 15s
+
 
 binary_sensor:
   - platform: template
@@ -1023,22 +1015,11 @@ text_sensor:
       entity_category: diagnostic
       icon: mdi:wifi-settings
       update_interval: 15s
+    mac_address:
+      name: "ESP32 | MAC"
+      entity_category: diagnostic
+      icon: mdi:card-bulleted-settings
 
-  - platform: template
-    name: "ESP32 | MAC"
-    entity_category: diagnostic
-    icon: mdi:card-bulleted-settings
-    lambda: |-
-      uint64_t mac = ESP.getEfuseMac();
-      char mac_str[18];
-      snprintf(mac_str, sizeof(mac_str), "%02X:%02X:%02X:%02X:%02X:%02X",
-        (uint8_t)(mac >> 40),
-        (uint8_t)(mac >> 32),
-        (uint8_t)(mac >> 24),
-        (uint8_t)(mac >> 16),
-        (uint8_t)(mac >> 8),
-        (uint8_t)(mac));
-      return std::string(mac_str);
 
   - platform: template
     name: "ESP32 | WiFi Strength"
@@ -1046,7 +1027,7 @@ text_sensor:
     icon: mdi:signal-cellular-3
     update_interval: 15s
     lambda: |-
-      int rssi = WiFi.RSSI();
+      int rssi = wifi::global_wifi_component->wifi_rssi();
       if (rssi < -90) {
         return std::string("Very Weak");
       } else if (rssi < -80) {
@@ -1058,4 +1039,18 @@ text_sensor:
       } else {
         return std::string("Very Strong");
       }
+
+  - platform: template
+    name: "ESP32 | Uptime"
+    icon: mdi:sort-clock-descending
+    entity_category: diagnostic
+    update_interval: 15s
+    lambda: |-
+      int uptime = id(esp32_uptime_seconds).state;
+      int hours = uptime / 3600;
+      int minutes = (uptime % 3600) / 60;
+      int seconds = uptime % 60;
+      char buffer[10];
+      snprintf(buffer, sizeof(buffer), "%02d:%02d:%02d", hours, minutes, seconds);
+      return std::string(buffer);
 


### PR DESCRIPTION
## Summary
- fix ESPHome yaml for esp-idf
- use wifi_info component for MAC address
- derive wifi RSSI using wifi_signal
- expose formatted uptime as text sensor

## Testing
- `yamllint -d relaxed src/sensy_two.yaml`
- `esphome config src/sensy_two.yaml`

------
https://chatgpt.com/codex/tasks/task_e_687f5380fdf0832aa46f74786b30fedf