### PR TITLE
Add point/person frame toggle

### DIFF
--- a/src/components/sensy_two/__init__.py
+++ b/src/components/sensy_two/__init__.py
@@ -3,6 +3,8 @@ import esphome.config_validation as cv
 from esphome.components import uart, sensor, text_sensor
 from esphome.const import CONF_ID, CONF_UART_ID
 
+CONF_USE_PERSON_FRAMES = "use_person_frames"
+
 DEPENDENCIES = ["uart"]
 AUTO_LOAD = ["sensor", "text_sensor"]
 
@@ -42,6 +44,7 @@ CONFIG_SCHEMA = (
     .extend({cv.Optional(key): sensor.sensor_schema() for key in SENSOR_KEYS})
     .extend({cv.Optional(key): text_sensor.text_sensor_schema() for key in TEXT_SENSOR_KEYS})
     .extend(cv.COMPONENT_SCHEMA)
+    .extend({cv.Optional(CONF_USE_PERSON_FRAMES, default=True): cv.boolean})
 )
 
 async def to_code(config):
@@ -57,3 +60,6 @@ async def to_code(config):
     for key in TEXT_SENSOR_KEYS:
         if key in config:
             await text_sensor.register_text_sensor(getattr(var, key), config[key])
+
+    if CONF_USE_PERSON_FRAMES in config:
+        cg.add(var.set_use_person_frames(config[CONF_USE_PERSON_FRAMES]))

--- a/src/sensy_two.yaml
+++ b/src/sensy_two.yaml
@@ -856,6 +856,19 @@ number:
       then:
         - lambda: 'id(sensy_component)->set_rotation_z_deg(id(rotation_z).state);'
 
+switch:
+  - platform: template
+    id: use_person_frames
+    name: "Use Person Frames"
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
+    lambda: |-
+      return id(sensy_component)->get_use_person_frames();
+    turn_on_action:
+      - lambda: 'id(sensy_component)->set_use_person_frames(true);'
+    turn_off_action:
+      - lambda: 'id(sensy_component)->set_use_person_frames(false);'
+
 button:
   - platform: template
     name: "RADAR | Restart Module"


### PR DESCRIPTION
## Summary
- add config option for selecting point or person frames
- implement parser support for skipping unused frames
- expose runtime switch in YAML example

## Testing
- `python -m py_compile src/components/sensy_two/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6888ac7dbcf0832a8a1c752e59122cd2