### PR TITLE
Add Q value filtering slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,10 @@ matching the Sensy-One reference implementation.
 Number entities can be used to rotate the reported coordinates around the X,
 Y and Z axes. Updating these values calls `set_rotation_x_deg`,
 `set_rotation_y_deg` and `set_rotation_z_deg` on the component.
+
+### Quality Filtering
+
+Persons reported by the radar include a quality value `q`. A template number
+entity `Quality Threshold` adjusts the minimum acceptable value. The YAML
+slider updates this threshold by calling `set_q_threshold` on the component,
+and detections with a lower quality are ignored.

--- a/src/components/sensy_two/sensy_two_component.h
+++ b/src/components/sensy_two/sensy_two_component.h
@@ -86,6 +86,7 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
     this->write_str(cmd);
     delay(100);
   }
+  void set_q_threshold(uint32_t value) { q_threshold_ = value; }
   void radar_seeking() { this->write_str("AT+SEEKING\n"); delay(100); }
   void radar_restart() { this->write_str("AT+RESET\n"); delay(100); }
   void radar_capture() { this->write_str("AT+SETTING\n"); delay(100); }
@@ -273,6 +274,7 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
   uint32_t last_frame_ms_ = 0;
   uint32_t last_reinit_ms_ = 0;
   uint32_t frame_timeout_ms_ = 10000;
+  uint32_t q_threshold_ = 0;
 
   struct Person {
     uint32_t q;
@@ -667,6 +669,8 @@ class SensyTwoComponent : public Component, public uart::UARTDevice {
     std::array<bool, MAX_TARGETS> seen{};
     seen.fill(false);
     for (const auto &p : persons) {
+      if (p.q < q_threshold_)
+        continue;
       if (fabsf(p.x) < 1e-4f && fabsf(p.y) < 1e-4f && fabsf(p.z) < 1e-4f) {
         size_t idx = find_index_for_id(p.id);
         if (idx != MAX_TARGETS) {

--- a/src/sensy_two.yaml
+++ b/src/sensy_two.yaml
@@ -815,6 +815,20 @@ number:
     entity_category: config
 
   - platform: template
+    id: quality_threshold
+    name: "Quality Threshold"
+    min_value: 0
+    max_value: 100
+    step: 1
+    optimistic: true
+    restore_value: true
+    initial_value: 0
+    entity_category: config
+    on_value:
+      then:
+        - lambda: 'id(sensy_component)->set_q_threshold((uint32_t)id(quality_threshold).state);'
+
+  - platform: template
     id: rotation_x
     name: "Rotation X"
     unit_of_measurement: "°"


### PR DESCRIPTION
## Summary
- allow filtering radar detections by quality
- expose `Quality Threshold` slider in YAML
- document feature in README

## Testing
- `g++ -std=c++17 -c src/components/sensy_two/sensy_two_component.h -o /tmp/out.o` *(fails: esphome.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6888c2021788832aa68b226eb91fb89a